### PR TITLE
Add support for shlex 

### DIFF
--- a/cmd3/shell.py
+++ b/cmd3/shell.py
@@ -91,6 +91,7 @@ import logging
 import os
 import pkg_resources  # part of setuptools
 import readline
+import shlex
 import sys
 import textwrap
 import traceback
@@ -229,7 +230,8 @@ def command(func):
     def new(instance, args):
                 # instance.new.__doc__ = doc
         try:
-            arguments = docopt(doc, help=True, argv=args)
+            argv = shlex.split(args)
+            arguments = docopt(doc, help=True, argv=argv)
             func(instance, args, arguments)
         except SystemExit:
             if not args in ('-h', '--help'):


### PR DESCRIPTION
Not sure if this is a helpful patch...

When using a command defined like the following:

  """Usage:
       log &lt;comment&gt;
  """

It is not possible to issue a command such as:

  log "an argument that contains spaces"

This will be broken into

  ['log', '"an', 'argument', 'that', 'contains', 'spaces"']

Which will break when it hits "log &lt;comment&gt;".

The reason for this is by passing 

  docopt(doc, help=True, argv=args)

args ends up within docopt.TokenStream's **init** where the code reads:

  self += source.split() if hasattr(source, 'split') else source

source.split() splits on whitespace without respecting quotes.

By going through shlex's parse, it will break the arg string into fragments that (to me) seem a bit more regular and make it possible to supply arguments with spaces.

shlex is also apparently a part of the standard library so it probably won't cause a troublesome dependancy.
